### PR TITLE
Add option to return the stacktrace if transaction fails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: erlang
 otp_release:
-  - 20.2
+  - 20.3
 script:
   - rebar3 do dialyzer, ct

--- a/migration.sql
+++ b/migration.sql
@@ -21,7 +21,7 @@ CREATE TABLE IF NOT EXISTS `people` (
  `weird_field2`  VARCHAR(100),
  `weird_field3`  VARCHAR(100),
   PRIMARY KEY(`ID`)
-);gst
+);
 
 ## People Table
 DROP TABLE IF EXISTS autoincrement;

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,7 +1,7 @@
 {"1.1.0",
 [{<<"cross_db">>,
   {git,"https://github.com/cabol/cross_db",
-       {ref,"312c8f8cac344ce498cf18b1e154f3c3f895e577"}},
+       {ref,"1bbe07ab28691dd9c664b70647ed59b0e1884d01"}},
   0},
  {<<"iso8601">>,{pkg,<<"iso8601">>,<<"1.2.3">>},1},
  {<<"mysql">>,

--- a/test/xdb_mysql_adapter_transaction_SUITE.erl
+++ b/test/xdb_mysql_adapter_transaction_SUITE.erl
@@ -62,8 +62,8 @@ t_transaction_exception(Config) ->
       #{b := _B} = A
     end),
 
-  {error, undef} =
+  {error, undef, _} =
     Repo:transaction(fun() ->
       Repo:in_transaction(Repo, 2)
-    end),
+    end, [{return_stacktrace, true}]),
   ok.


### PR DESCRIPTION
Hi, this commit adds an option to the transaction to return a stacktrace in case of failure. This is super useful for debugging.